### PR TITLE
APPOPS-16037: Added cache-manifest caching to localStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ cdn
 
 .yalc
 yalc.lock
+
+# Ide config files
+.idea
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,6 +1351,12 @@
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
+        "json5": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "dev": true
+        },
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -1648,6 +1654,42 @@
           "requires": {
             "path-type": "^4.0.0"
           }
+        },
+        "esbuild": {
+          "version": "0.14.54",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+          "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+          "dev": true,
+          "requires": {
+            "@esbuild/linux-loong64": "0.14.54",
+            "esbuild-android-64": "0.14.54",
+            "esbuild-android-arm64": "0.14.54",
+            "esbuild-darwin-64": "0.14.54",
+            "esbuild-darwin-arm64": "0.14.54",
+            "esbuild-freebsd-64": "0.14.54",
+            "esbuild-freebsd-arm64": "0.14.54",
+            "esbuild-linux-32": "0.14.54",
+            "esbuild-linux-64": "0.14.54",
+            "esbuild-linux-arm": "0.14.54",
+            "esbuild-linux-arm64": "0.14.54",
+            "esbuild-linux-mips64le": "0.14.54",
+            "esbuild-linux-ppc64le": "0.14.54",
+            "esbuild-linux-riscv64": "0.14.54",
+            "esbuild-linux-s390x": "0.14.54",
+            "esbuild-netbsd-64": "0.14.54",
+            "esbuild-openbsd-64": "0.14.54",
+            "esbuild-sunos-64": "0.14.54",
+            "esbuild-windows-32": "0.14.54",
+            "esbuild-windows-64": "0.14.54",
+            "esbuild-windows-arm64": "0.14.54"
+          }
+        },
+        "esbuild-linux-64": {
+          "version": "0.14.54",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+          "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+          "dev": true,
+          "optional": true
         },
         "fast-glob": {
           "version": "3.2.12",
@@ -2489,9 +2531,9 @@
       "dev": true
     },
     "@types/lodash.clonedeep": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
+      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -3248,7 +3290,7 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "array-union": {
@@ -3412,13 +3454,13 @@
       }
     },
     "babel-loader": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
-      "integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
+      "integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^3.3.1",
-        "loader-utils": "^2.0.0",
+        "loader-utils": "^1.4.0",
         "make-dir": "^3.1.0",
         "schema-utils": "^2.6.5"
       },
@@ -3630,23 +3672,29 @@
       }
     },
     "body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
+        "depd": "~1.1.2",
+        "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "on-finished": "~2.3.0",
+        "qs": "6.9.7",
+        "raw-body": "2.4.3",
+        "type-is": "~1.6.18"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.7",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+          "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+          "dev": true
+        }
       }
     },
     "boxen": {
@@ -3916,9 +3964,9 @@
       "dev": true
     },
     "chardet": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.0.tgz",
-      "integrity": "sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.4.0.tgz",
+      "integrity": "sha512-NpwMDdSIprbYx1CLnfbxEIarI0Z+s9MssEgggMNheGM+WD68yOhV7IEA/3r6tr0yTRgQD0HuZJDw32s99i6L+A==",
       "dev": true
     },
     "check-node-version": {
@@ -4073,12 +4121,12 @@
       }
     },
     "cli-progress": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
-      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
+      "integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
       "dev": true,
       "requires": {
-        "string-width": "^4.2.3"
+        "string-width": "^4.2.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -4107,9 +4155,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
       "dev": true
     },
     "cli-truncate": {
@@ -4159,9 +4207,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "strip-ansi": {
@@ -4178,7 +4226,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-deep": {
@@ -4287,7 +4335,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "component-emitter": {
@@ -4387,7 +4435,7 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
     "copy-descriptor": {
@@ -4551,9 +4599,9 @@
       }
     },
     "date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
       "dev": true
     },
     "debounce-fn": {
@@ -4626,9 +4674,9 @@
       "dev": true
     },
     "defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -4843,15 +4891,15 @@
       "dev": true
     },
     "depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-newline": {
@@ -4935,7 +4983,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "electron-to-chromium": {
@@ -4974,7 +5022,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
@@ -5041,35 +5089,6 @@
       "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
       "dev": true
     },
-    "esbuild": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-      "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
-      "dev": true,
-      "requires": {
-        "@esbuild/linux-loong64": "0.14.54",
-        "esbuild-android-64": "0.14.54",
-        "esbuild-android-arm64": "0.14.54",
-        "esbuild-darwin-64": "0.14.54",
-        "esbuild-darwin-arm64": "0.14.54",
-        "esbuild-freebsd-64": "0.14.54",
-        "esbuild-freebsd-arm64": "0.14.54",
-        "esbuild-linux-32": "0.14.54",
-        "esbuild-linux-64": "0.14.54",
-        "esbuild-linux-arm": "0.14.54",
-        "esbuild-linux-arm64": "0.14.54",
-        "esbuild-linux-mips64le": "0.14.54",
-        "esbuild-linux-ppc64le": "0.14.54",
-        "esbuild-linux-riscv64": "0.14.54",
-        "esbuild-linux-s390x": "0.14.54",
-        "esbuild-netbsd-64": "0.14.54",
-        "esbuild-openbsd-64": "0.14.54",
-        "esbuild-sunos-64": "0.14.54",
-        "esbuild-windows-32": "0.14.54",
-        "esbuild-windows-64": "0.14.54",
-        "esbuild-windows-arm64": "0.14.54"
-      }
-    },
     "esbuild-android-64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
@@ -5116,13 +5135,6 @@
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
       "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
       "dev": true,
       "optional": true
     },
@@ -5225,7 +5237,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
@@ -5509,7 +5521,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter3": {
@@ -5618,54 +5630,53 @@
       }
     },
     "express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
+      "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.19.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.4.2",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "2.0.0",
+        "depd": "~1.1.2",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
-        "http-errors": "2.0.0",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.3.0",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.9.7",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.17.2",
+        "serve-static": "1.14.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~1.5.0",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "cookie": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-          "dev": true
-        },
         "path-to-regexp": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.9.7",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+          "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
           "dev": true
         }
       }
@@ -5801,9 +5812,9 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
-      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==",
       "dev": true
     },
     "fast-safe-stringify": {
@@ -5839,7 +5850,7 @@
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -5878,9 +5889,9 @@
       }
     },
     "filesize": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
-      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
+      "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==",
       "dev": true
     },
     "fill-range": {
@@ -5909,28 +5920,28 @@
     "filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
       "dev": true
     },
     "finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.3.0",
         "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
+        "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       }
     },
     "find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -6019,9 +6030,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
     },
     "for-in": {
@@ -6065,7 +6076,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs-constants": {
@@ -6158,7 +6169,7 @@
     "get-them-args": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
-      "integrity": "sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==",
+      "integrity": "sha1-dKILqKSr7OWuGZrQPyvMaP38m6U=",
       "dev": true
     },
     "get-value": {
@@ -6177,19 +6188,19 @@
       }
     },
     "git-up": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.5.tgz",
-      "integrity": "sha512-YUvVDg/vX3d0syBsk/CKUTib0srcQME0JyHkL5BaYdwLsiCslPWmDSi8PUMo9pXYjrryMcmsCoCgsTpSCJEQaA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.2.tgz",
+      "integrity": "sha512-kbuvus1dWQB2sSW4cbfTeGpCMd8ge9jx9RKnhXhuJ7tnvT+NIrTVfYZxjtflZddQYcmdOTlkAcjmx7bor+15AQ==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
-        "parse-url": "^6.0.0"
+        "parse-url": "^5.0.0"
       }
     },
     "git-url-parse": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.6.0.tgz",
-      "integrity": "sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==",
+      "version": "11.4.4",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.4.4.tgz",
+      "integrity": "sha512-Y4o9o7vQngQDIU9IjyCmRJBin5iYjI5u9ZITnddRZpD7dcCFQj2sL2XuMNbLRE4b4B/4ENPsp2Q8P44fjAZ0Pw==",
       "dev": true,
       "requires": {
         "git-up": "^4.0.0"
@@ -6442,15 +6453,15 @@
       "dev": true
     },
     "http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "dev": true,
       "requires": {
-        "depd": "2.0.0",
+        "depd": "~1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.1"
       }
     },
@@ -6868,12 +6879,12 @@
       "dev": true
     },
     "is-ssh": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
-      "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
+      "integrity": "sha512-elEw0/0c2UscLrNG+OAorbP539E3rhliKPg+hDMWN9VwrDXfYK+4PBEykDPfxlYYtQvl84TascnQyobfQLHEhQ==",
       "dev": true,
       "requires": {
-        "protocols": "^2.0.1"
+        "protocols": "^1.1.0"
       }
     },
     "is-stream": {
@@ -6916,9 +6927,9 @@
       "dev": true
     },
     "is2": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
-      "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.6.tgz",
+      "integrity": "sha512-+Z62OHOjA6k2sUDOKXoZI3EXv7Fb1K52jpTBLbkfx62bcUeSsrTBLhEquCRDKTx0XE5XbHcG/S2vrtE3lnEDsQ==",
       "dev": true,
       "requires": {
         "deep-is": "^0.1.3",
@@ -8031,10 +8042,13 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -8336,14 +8350,14 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
+        "json5": "^1.0.1"
       }
     },
     "locate-path": {
@@ -8364,7 +8378,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.debounce": {
@@ -8449,13 +8463,13 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "supports-color": {
@@ -8576,7 +8590,7 @@
     "map-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
-      "integrity": "sha512-BbShUnr5OartXJe1GeccAWtfro11hhgNJg6G9/UtWKjVGvV5U4C09cg5nk8JUevhXODaXY+hQ3xxMUKSs62ONQ==",
+      "integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA=",
       "dev": true
     },
     "map-visit": {
@@ -8591,7 +8605,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "memory-fs": {
@@ -8630,7 +8644,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
     "merge-stream": {
@@ -8648,7 +8662,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "micromatch": {
@@ -8803,37 +8817,10 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
-      }
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -8972,9 +8959,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
     },
     "npm-run-path": {
@@ -9042,13 +9029,13 @@
     "object-filter": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
-      "integrity": "sha512-NahvP2vZcy1ZiiYah30CEPw0FpDcSkSePJBMpzl5EQgCmISijiGuJm3SPYp7U+Lf2TljyaIw3E5EgkEx/TNEVA==",
+      "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g=",
       "dev": true
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
       "dev": true
     },
     "object-keys": {
@@ -9088,9 +9075,9 @@
       }
     },
     "on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
         "ee-first": "1.1.1"
@@ -9309,43 +9296,27 @@
       }
     },
     "parse-path": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.4.tgz",
-      "integrity": "sha512-Z2lWUis7jlmXC1jeOG9giRO2+FsuyNipeQ43HAjqAZjwSe3SEf+q/84FGPHoso3kyntbxa4c4i77t3m6fGf8cw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.3.tgz",
+      "integrity": "sha512-9Cepbp2asKnWTJ9x2kpw6Fe8y9JDbqwahGCTvklzd/cEq5C5JC59x2Xb0Kx+x0QZ8bvNquGO8/BWP0cwBHzSAA==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
         "protocols": "^1.4.0",
         "qs": "^6.9.4",
         "query-string": "^6.13.8"
-      },
-      "dependencies": {
-        "protocols": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
-          "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
-          "dev": true
-        }
       }
     },
     "parse-url": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.5.tgz",
-      "integrity": "sha512-e35AeLTSIlkw/5GFq70IN7po8fmDUjpDPY1rIK+VubRfsUvBonjQ+PBZG+vWMACnQSmNlvl524IucoDmcioMxA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.2.tgz",
+      "integrity": "sha512-Czj+GIit4cdWtxo3ISZCvLiUjErSo0iI3wJ+q9Oi3QuMYTI6OZu+7cewMWZ+C1YAnKhYTk6/TLuhIgCypLthPA==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
-        "normalize-url": "^6.1.0",
+        "normalize-url": "^3.3.0",
         "parse-path": "^4.0.0",
         "protocols": "^1.4.0"
-      },
-      "dependencies": {
-        "protocols": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
-          "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
-          "dev": true
-        }
       }
     },
     "parse5": {
@@ -9399,7 +9370,7 @@
     "path-root": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
         "path-root-regex": "^0.1.0"
@@ -9408,7 +9379,7 @@
     "path-root-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
     "path-to-regexp": {
@@ -9436,7 +9407,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
@@ -9545,7 +9516,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
       }
@@ -9630,9 +9601,9 @@
       }
     },
     "protocols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
+      "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
       "dev": true
     },
     "proxy-addr": {
@@ -9689,9 +9660,9 @@
       }
     },
     "qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -9731,13 +9702,13 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
+      "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
-        "http-errors": "2.0.0",
+        "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
@@ -9862,7 +9833,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
@@ -10103,7 +10074,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
@@ -10143,7 +10114,7 @@
         "global-dirs": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-          "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
             "ini": "^1.3.4"
@@ -10416,24 +10387,24 @@
       }
     },
     "send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "http-errors": "1.8.1",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.3.0",
         "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "mime": {
@@ -10460,15 +10431,15 @@
       }
     },
     "serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
+      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
       "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.17.2"
       }
     },
     "set-blocking": {
@@ -10587,9 +10558,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -10882,7 +10853,7 @@
     "stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
       "dev": true
     },
     "stack-utils": {
@@ -10924,9 +10895,9 @@
       }
     },
     "statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
     "stealthy-require": {
@@ -10938,7 +10909,7 @@
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "dev": true
     },
     "string-argv": {
@@ -11749,7 +11720,7 @@
     "unixify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
-      "integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
       "dev": true,
       "requires": {
         "normalize-path": "^2.1.1"
@@ -11758,7 +11729,7 @@
         "normalize-path": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
@@ -11769,7 +11740,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "unset-value": {
@@ -11884,7 +11855,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
@@ -11931,7 +11902,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
@@ -11985,7 +11956,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
@@ -12244,9 +12215,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
@@ -12270,7 +12241,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "strip-ansi": {
@@ -12409,15 +12380,15 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
       }
     },
     "yargs-parser": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
-      "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+      "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
@@ -12427,7 +12398,7 @@
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/src/CacheManifest.ts
+++ b/src/CacheManifest.ts
@@ -1,0 +1,123 @@
+import { CACHE_MANIFEST_DATA_KEY, CACHE_MANIFEST_TIME_KEY, CACHE_MANIFEST_TTL } from './constants'
+import getCookieValue from './getCookieValue'
+
+/**
+ * Loads the routes from cache-manifest.js file
+ * and cache them in localStorage for specified period of time.
+ *
+ * Example:
+ *
+ * ```js
+ *  let cacheManifest = new CacheManifest(3600); // cache routes for 1 hour
+ *  let routes = cacheManifest().getRoutes();
+ * ```
+ */
+export default class CacheManifest {
+  private ttl: number
+  private routes: Array<any>
+
+  /**
+     @param ttl The number of seconds for how long the routes are cached
+     */
+  constructor(ttl: number = CACHE_MANIFEST_TTL) {
+    this.ttl = ttl > 0 ? ttl : 0
+    this.routes = []
+    this.load()
+  }
+
+  /**
+   * Loads the routes either from localStorage cache or from cache-manifest.js file
+   */
+  private load(): void {
+    if (!this.isCacheFresh()) {
+      this.download()
+      return
+    }
+    this.routes = this.getCacheroutes()
+  }
+
+  /**
+   * @returns The array of routes
+   */
+  public getRoutes(): Array<any> {
+    // when routes was loaded, return them
+    if (this.routes && this.routes.length > 0) {
+      return this.routes
+    }
+
+    // when routes was downloaded, save them to local cache
+    // @ts-ignore
+    let windowManifest =
+      window.__EDGIO_CACHE_MANIFEST__ ||
+      window.__LAYER0_CACHE_MANIFEST__ ||
+      window.__XDN_CACHE_MANIFEST__
+    if (windowManifest) {
+      this.routes = windowManifest
+      this.setCacheroutes(this.routes)
+      this.setCacheTime(new Date().getTime())
+    }
+
+    return this.routes
+  }
+
+  /**
+   * Returns the time of cache creation from localStorage
+   * @returns The time of cache creation or null
+   */
+  private getCacheTime(): number | null {
+    let time = localStorage.getItem(CACHE_MANIFEST_TIME_KEY)
+    return time ? parseInt(time) : null
+  }
+
+  /**
+   * Sets the time of cache creation to localStorage
+   */
+  private setCacheTime(time: number): void {
+    localStorage.setItem(CACHE_MANIFEST_TIME_KEY, time.toString())
+  }
+
+  /**
+   * Returns the array of routes from localStorage cache
+   * @returns Array<any>
+   */
+  private getCacheroutes(): Array<any> {
+    return JSON.parse(localStorage.getItem(CACHE_MANIFEST_DATA_KEY) ?? '[]')
+  }
+
+  /**
+   * Saves the array of routes to localStorage cache
+   */
+  private setCacheroutes(routes: Array<any>): void {
+    localStorage.setItem(CACHE_MANIFEST_DATA_KEY, JSON.stringify(routes))
+  }
+
+  /**
+   * Returns the true when localStorage cache is not expired
+   * @returns boolean
+   */
+  private isCacheFresh(): boolean {
+    let cacheSavedTime = this.getCacheTime()
+    return cacheSavedTime != null && new Date().getTime() - cacheSavedTime <= this.ttl * 1000
+  }
+
+  /**
+   * Downloads the cache-manifest.js file by adding it to script tag
+   */
+  private download() {
+    const scriptEl = document.createElement('script')
+    scriptEl.setAttribute('defer', 'on')
+
+    if (getCookieValue('edgio_environment_id_info')) {
+      scriptEl.setAttribute('src', '/__edgio__/cache-manifest.js')
+      document.head.appendChild(scriptEl)
+      return
+    }
+    if (getCookieValue('layer0_environment_id_info')) {
+      scriptEl.setAttribute('src', '/__layer0__/cache-manifest.js')
+      document.head.appendChild(scriptEl)
+      return
+    }
+    scriptEl.setAttribute('src', '/__xdn__/cache-manifest.js')
+    document.head.appendChild(scriptEl)
+  }
+}

--- a/src/CacheManifest.ts
+++ b/src/CacheManifest.ts
@@ -33,27 +33,24 @@ export default class CacheManifest {
       this.download()
       return
     }
-    this.routes = this.getCacheroutes()
+    this.routes = this.getCacheRoutes()
   }
 
   /**
    * @returns The array of routes
    */
   public getRoutes(): Array<any> {
-    // when routes was loaded, return them
+    // when routes were loaded, return them
     if (this.routes && this.routes.length > 0) {
       return this.routes
     }
 
-    // when routes was downloaded, save them to local cache
+    // when routes were downloaded, save them to local cache
     // @ts-ignore
-    let windowManifest =
-      window.__EDGIO_CACHE_MANIFEST__ ||
-      window.__LAYER0_CACHE_MANIFEST__ ||
-      window.__XDN_CACHE_MANIFEST__
+    let windowManifest = window.__EDGIO_CACHE_MANIFEST__ || window.__LAYER0_CACHE_MANIFEST__ || window.__XDN_CACHE_MANIFEST__
     if (windowManifest) {
       this.routes = windowManifest
-      this.setCacheroutes(this.routes)
+      this.setCacheRoutes(this.routes)
       this.setCacheTime(new Date().getTime())
     }
 
@@ -80,14 +77,14 @@ export default class CacheManifest {
    * Returns the array of routes from localStorage cache
    * @returns Array<any>
    */
-  private getCacheroutes(): Array<any> {
+  private getCacheRoutes(): Array<any> {
     return JSON.parse(localStorage.getItem(CACHE_MANIFEST_DATA_KEY) ?? '[]')
   }
 
   /**
    * Saves the array of routes to localStorage cache
    */
-  private setCacheroutes(routes: Array<any>): void {
+  private setCacheRoutes(routes: Array<any>): void {
     localStorage.setItem(CACHE_MANIFEST_DATA_KEY, JSON.stringify(routes))
   }
 
@@ -97,7 +94,7 @@ export default class CacheManifest {
    */
   private isCacheFresh(): boolean {
     let cacheSavedTime = this.getCacheTime()
-    return cacheSavedTime != null && new Date().getTime() - cacheSavedTime <= this.ttl * 1000
+    return cacheSavedTime != null && new Date().getTime() - cacheSavedTime < this.ttl * 1000
   }
 
   /**

--- a/src/Metrics.ts
+++ b/src/Metrics.ts
@@ -1,5 +1,5 @@
 import { getCLS, getFID, getLCP, Metric, getFCP, getTTFB } from 'web-vitals'
-import { DEST_URL, SEND_DELAY } from './constants'
+import { CACHE_MANIFEST_TTL, DEST_URL, SEND_DELAY } from './constants'
 import getCookieValue from './getCookieValue'
 import getServerTiming from './getServerTiming'
 import isChrome from './isChrome'
@@ -7,6 +7,7 @@ import Router from './Router'
 import uuid from './uuid'
 import debounce from 'lodash.debounce'
 import getSelectorForElement from './getSelectorForElement'
+import CacheManifest from './CacheManifest'
 
 let rumClientVersion: string
 
@@ -54,6 +55,10 @@ export interface MetricsOptions {
    * Set to true to output all measurements to the console
    */
   debug?: boolean
+  /**
+   * The number of seconds for how long the content of cache-manifest.js file is cached in localStorage
+   */
+  cacheManifestTTL?: number
 }
 
 interface MetricsConstructor {
@@ -92,12 +97,14 @@ class BrowserMetrics implements Metrics {
   private clientNavigationHasOccurred: boolean = false
   private edgioEnvironmentID?: string
   private splitTestVariant?: string
-  private connectionType?:  string
+  private connectionType?: string
+  private manifest?: CacheManifest
 
   constructor(options: MetricsOptions = {}) {
     this.originalURL = location.href
     this.options = options
-    this.edgioEnvironmentID = getCookieValue('edgio_eid') || getCookieValue('layer0_eid') || getCookieValue('xdn_eid')
+    this.edgioEnvironmentID =
+      getCookieValue('edgio_eid') || getCookieValue('layer0_eid') || getCookieValue('xdn_eid')
     this.token = options.token || this.edgioEnvironmentID
     this.sendTo = `${this.options.sendTo || DEST_URL}/${this.token}`
     this.pageID = uuid()
@@ -110,29 +117,10 @@ class BrowserMetrics implements Metrics {
       console.debug('could not obtain navigator.connection metrics')
     }
 
-
     /* istanbul ignore else */
     if (this.edgioEnvironmentID != null || location.hostname === 'localhost') {
-      this.downloadRouteManifest()
+      this.manifest = new CacheManifest(options.cacheManifestTTL ?? CACHE_MANIFEST_TTL)
     }
-  }
-
-  private downloadRouteManifest() {
-    const scriptEl = document.createElement('script')
-    scriptEl.setAttribute('defer', 'on')
-
-    if (getCookieValue('edgio_environment_id_info')) {
-      scriptEl.setAttribute('src', '/__edgio__/cache-manifest.js')
-      document.head.appendChild(scriptEl)
-      return
-    }
-    if(getCookieValue('layer0_environment_id_info')) {
-      scriptEl.setAttribute('src', '/__layer0__/cache-manifest.js')
-      document.head.appendChild(scriptEl)
-      return
-    }
-    scriptEl.setAttribute('src', '/__xdn__/cache-manifest.js')
-    document.head.appendChild(scriptEl)
   }
 
   collect() {
@@ -276,7 +264,12 @@ class BrowserMetrics implements Metrics {
   }
 
   getAppVersion(timing: any) {
-    return this.options.appVersion || timing['edgio-deployment-id'] || timing['layer0-deployment-id'] || timing['xdn-deployment-id']
+    return (
+      this.options.appVersion ||
+      timing['edgio-deployment-id'] ||
+      timing['layer0-deployment-id'] ||
+      timing['xdn-deployment-id']
+    )
   }
 
   getSplitTestVariant() {
@@ -304,8 +297,7 @@ class BrowserMetrics implements Metrics {
    * @returns
    */
   private getCurrentPageLabel() {
-    // @ts-ignore
-    const manifest = window.__EDGIO_CACHE_MANIFEST__ || window.__LAYER0_CACHE_MANIFEST__ || window.__XDN_CACHE_MANIFEST__
+    const manifest = this.manifest?.getRoutes() ?? []
 
     if (this.options.router) {
       return this.options.router.getPageLabel(location.href)

--- a/src/Metrics.ts
+++ b/src/Metrics.ts
@@ -103,8 +103,7 @@ class BrowserMetrics implements Metrics {
   constructor(options: MetricsOptions = {}) {
     this.originalURL = location.href
     this.options = options
-    this.edgioEnvironmentID =
-      getCookieValue('edgio_eid') || getCookieValue('layer0_eid') || getCookieValue('xdn_eid')
+    this.edgioEnvironmentID = getCookieValue('edgio_eid') || getCookieValue('layer0_eid') || getCookieValue('xdn_eid')
     this.token = options.token || this.edgioEnvironmentID
     this.sendTo = `${this.options.sendTo || DEST_URL}/${this.token}`
     this.pageID = uuid()
@@ -145,6 +144,7 @@ class BrowserMetrics implements Metrics {
   /**
    * Returns a promise that resolves once the specified metric has been collected.
    * @param getMetric
+   * @param params
    */
   private toPromise(getMetric: Function, ...params: any) {
     return new Promise<void>(resolve => {
@@ -344,7 +344,7 @@ class BrowserMetrics implements Metrics {
  * run on the server as might happen with Nuxt, Next, etc...
  */
 class ServerMetrics implements Metrics {
-  constructor(options: MetricsOptions) {}
+  constructor(_: MetricsOptions) {}
 
   collect() {
     return Promise.resolve()

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,5 @@
 export const DEST_URL = 'https://rum.ingress.layer0.co/ingress/rum/v1'
 export const SEND_DELAY = 500
+export const CACHE_MANIFEST_TTL = 3600
+export const CACHE_MANIFEST_DATA_KEY = 'edgio_rum_cache_manifest'
+export const CACHE_MANIFEST_TIME_KEY = 'edgio_rum_cache_manifest_time'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const DEST_URL = 'https://rum.ingress.layer0.co/ingress/rum/v1'
 export const SEND_DELAY = 500
 export const CACHE_MANIFEST_TTL = 3600
-export const CACHE_MANIFEST_DATA_KEY = 'edgio_rum_cache_manifest'
-export const CACHE_MANIFEST_TIME_KEY = 'edgio_rum_cache_manifest_time'
+export const CACHE_MANIFEST_DATA_KEY = 'rum_cache_manifest'
+export const CACHE_MANIFEST_TIME_KEY = 'rum_cache_manifest_time'

--- a/test/CacheManifest.test.js
+++ b/test/CacheManifest.test.js
@@ -1,12 +1,134 @@
-import CacheManifest from '../src/CacheManifest'
-import { CACHE_MANIFEST_TTL } from '../src/constants'
+import { CACHE_MANIFEST_TIME_KEY, CACHE_MANIFEST_TTL } from '../src/constants'
 
-jest.spyOn(Storage.prototype, 'setItem')
-Storage.prototype.setItem = jest.fn()
+describe('CacheManifest', () => {
+  let CacheManifest, scriptTag, routes, cookies
 
-describe('Metrics', () => {
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      CacheManifest = require('../src/CacheManifest').default
+    })
+
+    cookies = {}
+    jest.doMock('../src/getCookieValue', () => name => cookies[name])
+
+    routes = [
+      { route: '^.*$', criteriaPath: '/all', returnsResponse: false },
+      { route: '^/help$', criteriaPath: '/help', returnsResponse: true },
+      { route: '^/$', criteriaPath: '/', returnsResponse: true },
+    ]
+
+    scriptTag = document.createElement('script')
+    scriptTag.setAttribute('defer', 'on')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  it('should download cache-manifest.js file', () => {
+    const cacheManifest = new CacheManifest()
+
+    const downloadMethod = jest.spyOn(cacheManifest, 'download')
+    jest.spyOn(CacheManifest.prototype, 'isCacheFresh').mockImplementation(() => false)
+
+    cacheManifest.load()
+    expect(downloadMethod).toHaveBeenCalled()
+  })
+
+  it('should load routes from cache', () => {
+    const cacheManifest = new CacheManifest()
+
+    const getCacheRoutesMethod = jest
+      .spyOn(cacheManifest, 'getCacheRoutes')
+      .mockImplementation(() => routes)
+    jest.spyOn(CacheManifest.prototype, 'isCacheFresh').mockImplementation(() => true)
+
+    cacheManifest.load()
+    expect(getCacheRoutesMethod).toHaveBeenCalled()
+    expect(cacheManifest.getRoutes()).toBe(routes)
+  })
+
+  it('should return cache status', () => {
+    const ttl = 500
+    const cacheManifest = new CacheManifest(ttl)
+    try {
+      localStorage.setItem(
+        CACHE_MANIFEST_TIME_KEY,
+        (new Date().getTime() - 2 * ttl * 1000).toString()
+      )
+      expect(cacheManifest.isCacheFresh()).toBe(false)
+
+      localStorage.setItem(CACHE_MANIFEST_TIME_KEY, new Date().getTime().toString())
+      expect(cacheManifest.isCacheFresh()).toBe(true)
+    } finally {
+      localStorage.removeItem(CACHE_MANIFEST_TIME_KEY)
+    }
+  })
+
+  it('should load routes from window.__EDGIO_CACHE_MANIFEST__', () => {
+    const cacheManifest = new CacheManifest(0)
+    try {
+      window.__EDGIO_CACHE_MANIFEST__ = routes
+      expect(cacheManifest.getRoutes()).toBe(routes)
+    } finally {
+      delete window.__EDGIO_CACHE_MANIFEST__
+    }
+  })
+
+  it('should load routes from window.__LAYER0_CACHE_MANIFEST__', () => {
+    const cacheManifest = new CacheManifest(0)
+    try {
+      window.__LAYER0_CACHE_MANIFEST__ = routes
+      expect(cacheManifest.getRoutes()).toBe(routes)
+    } finally {
+      delete window.__LAYER0_CACHE_MANIFEST__
+    }
+  })
+
+  it('should load routes from window.__XDN_CACHE_MANIFEST__', () => {
+    const cacheManifest = new CacheManifest(0)
+    try {
+      window.__XDN_CACHE_MANIFEST__ = routes
+      expect(cacheManifest.getRoutes()).toBe(routes)
+    } finally {
+      delete window.__XDN_CACHE_MANIFEST__
+    }
+  })
+
+  it('should load /__edgio__/cache-manifest.js', () => {
+    jest.spyOn(document.head, 'appendChild')
+    cookies = { edgio_environment_id_info: '123' }
+    new CacheManifest(0)
+
+    scriptTag.setAttribute('src', '/__edgio__/cache-manifest.js')
+    expect(document.head.appendChild).toBeCalledWith(scriptTag)
+  })
+
+  it('should load /__layer0__/cache-manifest.js', () => {
+    jest.spyOn(document.head, 'appendChild')
+    cookies = { layer0_environment_id_info: '123' }
+    new CacheManifest(0)
+
+    scriptTag.setAttribute('src', '/__layer0__/cache-manifest.js')
+    expect(document.head.appendChild).toBeCalledWith(scriptTag)
+  })
+
+  it('should load /__xdn__/cache-manifest.js', () => {
+    jest.spyOn(document.head, 'appendChild')
+    new CacheManifest(0)
+
+    scriptTag.setAttribute('src', '/__xdn__/cache-manifest.js')
+    expect(document.head.appendChild).toBeCalledWith(scriptTag)
+  })
+
   it('should have default TTL', () => {
-    let cacheManifest = new CacheManifest()
+    const cacheManifest = new CacheManifest()
     expect(cacheManifest.ttl).toBe(CACHE_MANIFEST_TTL)
+  })
+
+  it('should have custom TTL', () => {
+    const cacheManifest = new CacheManifest(500)
+    expect(cacheManifest.ttl).toBe(500)
   })
 })

--- a/test/CacheManifest.test.js
+++ b/test/CacheManifest.test.js
@@ -123,12 +123,10 @@ describe('CacheManifest', () => {
   })
 
   it('should have default TTL', () => {
-    const cacheManifest = new CacheManifest()
-    expect(cacheManifest.ttl).toBe(CACHE_MANIFEST_TTL)
+    expect(new CacheManifest().ttl).toBe(CACHE_MANIFEST_TTL)
   })
 
   it('should have custom TTL', () => {
-    const cacheManifest = new CacheManifest(500)
-    expect(cacheManifest.ttl).toBe(500)
+    expect(new CacheManifest(500).ttl).toBe(500)
   })
 })

--- a/test/CacheManifest.test.js
+++ b/test/CacheManifest.test.js
@@ -1,0 +1,12 @@
+import CacheManifest from '../src/CacheManifest'
+import { CACHE_MANIFEST_TTL } from '../src/constants'
+
+jest.spyOn(Storage.prototype, 'setItem')
+Storage.prototype.setItem = jest.fn()
+
+describe('Metrics', () => {
+  it('should have default TTL', () => {
+    let cacheManifest = new CacheManifest()
+    expect(cacheManifest.ttl).toBe(CACHE_MANIFEST_TTL)
+  })
+})


### PR DESCRIPTION
The `cache-manifest.js` file content is now downloaded only once and then cached in `localStorage`.
The default expiration time of cache is set to 1hour (same as current browser cache TTL of `/__edgio__/cache-manifest.js` file).
The default TTL can be changed by providing `cacheManifestTTL` option.

Example:
```
new Metrics({
      token: 'my-edgio-rum-token',
      cacheManifestTTL: 300 // 5 minutes
}).collect()
```