### PR TITLE
APPOPS-16201: Added backward compatibility for older versions

### DIFF
--- a/src/CacheManifest.ts
+++ b/src/CacheManifest.ts
@@ -104,12 +104,20 @@ export default class CacheManifest {
     const scriptEl = document.createElement('script')
     scriptEl.setAttribute('defer', 'on')
 
-    if (getCookieValue('edgio_environment_id_info')) {
+    if (
+        getCookieValue('edgio_environment_id_info') ||
+        getCookieValue('edgio_eid') ||
+        getCookieValue('edgio_bucket')
+    ) {
       scriptEl.setAttribute('src', '/__edgio__/cache-manifest.js')
       document.head.appendChild(scriptEl)
       return
     }
-    if (getCookieValue('layer0_environment_id_info')) {
+    if (
+        getCookieValue('layer0_environment_id_info') ||
+        getCookieValue('layer0_eid') ||
+        getCookieValue('layer0_bucket')
+    ) {
       scriptEl.setAttribute('src', '/__layer0__/cache-manifest.js')
       document.head.appendChild(scriptEl)
       return


### PR DESCRIPTION
The current implementation might load the wrong `cache-manifest.js` when no `edgio_environment_id_info` cookie is presented.
This occurs on sites which are loading `@edgio/rum` from CDN and running on older version of layer0.
This MR should fix it.