### PR TITLE
Appops 17042 r2d2  rum update rum to be compatible w ec edge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgio/rum",
-  "version": "6.0.0",
+  "version": "7.0.0-alpha.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgio/rum",
-  "version": "7.0.0-alpha.0.0",
+  "version": "6.0.1",
   "license": "UNLICENSED",
   "dependencies": {
     "lodash.debounce": "^4.0.8",

--- a/src/Metrics.ts
+++ b/src/Metrics.ts
@@ -1,7 +1,7 @@
 import { getCLS, getFID, getLCP, Metric, getFCP, getTTFB } from 'web-vitals'
 import { CACHE_MANIFEST_TTL, DEST_URL, SEND_DELAY } from './constants'
 import getCookieValue from './getCookieValue'
-import getServerTiming from './getServerTiming'
+import getServerTiming, { ServerTiming } from './getServerTiming'
 import isChrome from './isChrome'
 import Router from './Router'
 import uuid from './uuid'
@@ -209,7 +209,7 @@ class BrowserMetrics implements Metrics {
    */
   private createPayload() {
     const timing = getServerTiming()
-    const edgioRoutes = timing['xrj']
+    const edgioRoutes = timing.xrj
     let pageLabel = this.options.pageLabel || this.options.router?.getPageLabel(this.originalURL)
 
     if (!pageLabel && edgioRoutes) {
@@ -247,15 +247,15 @@ class BrowserMetrics implements Metrics {
       ua: navigator.userAgent,
       w: window.screen.width,
       h: window.screen.height,
-      v: this.getAppVersion(timing),
+      v: this.getAppVersion(),
       cv: rumClientVersion,
       ht: this.isCacheHit(timing),
       l: pageLabel, // for backwards compatibility
       l0: pageLabel,
       lx: this.getCurrentPageLabel(),
-      c: this.options.country || timing['country'],
+      c: this.options.country || timing.edge_country,
       ct: this.connectionType,
-      epop: timing['edge_pop'],
+      epop: timing.edge_pop,
     }
 
     this.metrics = this.flushMetrics()
@@ -263,12 +263,13 @@ class BrowserMetrics implements Metrics {
     return JSON.stringify(data)
   }
 
-  getAppVersion(timing: any) {
+  getAppVersion() {
     return (
-      this.options.appVersion ||
-      timing['edgio-deployment-id'] ||
-      timing['layer0-deployment-id'] ||
-      timing['xdn-deployment-id']
+      // todo: should we use the version from the server timing header?
+      this.options.appVersion
+      // timing['edgio-deployment-id'] ||
+      // timing['layer0-deployment-id'] ||
+      // timing['xdn-deployment-id']
     )
   }
 
@@ -281,13 +282,20 @@ class BrowserMetrics implements Metrics {
     )
   }
 
-  isCacheHit(timing: any) {
+  isCacheHit(timing: ServerTiming) {
     if (this.options.cacheHit != null) {
       return this.options.cacheHit ? 1 : 0
     }
-    const cache = timing['edgio-cache'] || timing['layer0-cache'] || timing['xdn-cache']
-    if (cache?.includes('HIT')) return 1
-    return cache?.includes('MISS') ? 0 : null
+    
+    if (timing.edge_cache?.includes('HIT')) {
+      return 1
+    } 
+
+    if (timing.edge_cache?.includes('MISS')) {
+      return 0;
+    }
+
+    return null
   }
 
   /**

--- a/src/getServerTiming.ts
+++ b/src/getServerTiming.ts
@@ -1,10 +1,23 @@
 
-// This type is constructed from the implementation in Sailfish which can be found here:
+// Note: this custom ServerTiming type is combination of the old Layer0 and Sailfish ServerTiming types.
+// As for the Sailfish implementation you can find it at:
 // https://gitlab.com/limelight-networks/edgecast/mirrors/http-dev/sailfish/-/commit/b7bcbafe29945dece5530509556bf954a5bae566
 export type ServerTiming = {
+  // Salfish type
   edge_cache?: string
-  edge_pop?: string
   edge_country?: string
+
+  // Layer0 type
+  "edgio-cache"?: string,
+  "layer0-cache"?: string,
+  "xdn-cache"?: string,
+  "edgio-deployment-id"?: string,
+  "layer0-deployment-id"?: string,
+  "xdn-deployment-id"?: string,
+  country?: string
+
+  // These are the same between Layer0 and Sailfish
+  edge_pop?: string
   xrj?: string
 }
 

--- a/src/getServerTiming.ts
+++ b/src/getServerTiming.ts
@@ -1,6 +1,16 @@
+
+// This type is constructed from the implementation in Sailfish which can be found here:
+// https://gitlab.com/limelight-networks/edgecast/mirrors/http-dev/sailfish/-/commit/b7bcbafe29945dece5530509556bf954a5bae566
+export type ServerTiming = {
+  edge_cache?: string
+  edge_pop?: string
+  edge_country?: string
+  xrj?: string
+}
+
 /* istanbul ignore file */
 export default function getServerTiming() {
-  const timing: any = {}
+  const timing: Record<string, string> = {}
 
   try {
     // @ts-ignore
@@ -13,5 +23,5 @@ export default function getServerTiming() {
     console.debug('could not obtain serverTiming metrics', e)
   }
 
-  return timing
+  return timing as ServerTiming
 }

--- a/test/Metrics.test.ts
+++ b/test/Metrics.test.ts
@@ -187,10 +187,11 @@ describe('Metrics', () => {
         })
 
         timing = {
-          'edgio-cache': 'L1-HIT',
-          'edgio-deployment-id': 'deployment-1',
+          'edge_cache': 'HIT',
+          // Deployment currently not supporetd by Sailfish          
+          // 'edgio-deployment-id': 'deployment-1',
           xrj: '{ "path": "/p/:id" }',
-          country: 'USA',
+          edge_country: 'USA',
         }
 
         window.navigator.connection = { effectiveType: '4g' }
@@ -198,7 +199,7 @@ describe('Metrics', () => {
         expect(JSON.parse(metrics.createPayload())).toEqual({
           ...commonParams,
           t: validToken,
-          v: 'deployment-1',
+          //v: 'deployment-1',
           ht: 1,
           c: 'USA',
           l: '/p/:id',
@@ -219,16 +220,17 @@ describe('Metrics', () => {
         })
 
         timing = {
-          'xdn-cache': 'L1-HIT',
-          'xdn-deployment-id': 'deployment-2',
+          'edge_cache': 'L1-HIT',
+          // Deployment currently not supporetd by Sailfish
+          // 'xdn-deployment-id': 'deployment-2',
           xrj: '{ "path": "/p/:id" }',
-          country: 'USA',
+          edge_country: 'USA',
         }
 
         expect(JSON.parse(metrics.createPayload())).toEqual({
           ...commonParams,
           t: validToken,
-          v: 'deployment-2',
+          // v: 'deployment-2',
           ht: 1,
           c: 'USA',
           l: '/p/:id',
@@ -276,14 +278,14 @@ describe('Metrics', () => {
           ht: 1,
         })
 
-        timing = { 'xdn-cache': 'L1-HIT' }
+        timing = { 'edge_cache': 'L1-HIT' }
         metrics = new Metrics({ cacheManifestTTL: 0 })
         expect(JSON.parse(metrics.createPayload())).toEqual({
           ...commonParams,
           ht: 1,
         })
 
-        timing = { 'xdn-cache': 'L1-MISS' }
+        timing = { 'edge_cache': 'L1-MISS' }
         metrics = new Metrics({ cacheManifestTTL: 0 })
         expect(JSON.parse(metrics.createPayload())).toEqual({
           ...commonParams,

--- a/test/Metrics.test.ts
+++ b/test/Metrics.test.ts
@@ -188,8 +188,6 @@ describe('Metrics', () => {
 
         timing = {
           'edge_cache': 'HIT',
-          // Deployment currently not supporetd by Sailfish          
-          // 'edgio-deployment-id': 'deployment-1',
           xrj: '{ "path": "/p/:id" }',
           edge_country: 'USA',
         }
@@ -199,7 +197,6 @@ describe('Metrics', () => {
         expect(JSON.parse(metrics.createPayload())).toEqual({
           ...commonParams,
           t: validToken,
-          //v: 'deployment-1',
           ht: 1,
           c: 'USA',
           l: '/p/:id',
@@ -220,9 +217,7 @@ describe('Metrics', () => {
         })
 
         timing = {
-          'edge_cache': 'L1-HIT',
-          // Deployment currently not supporetd by Sailfish
-          // 'xdn-deployment-id': 'deployment-2',
+          'edge_cache': 'HIT',
           xrj: '{ "path": "/p/:id" }',
           edge_country: 'USA',
         }
@@ -230,7 +225,36 @@ describe('Metrics', () => {
         expect(JSON.parse(metrics.createPayload())).toEqual({
           ...commonParams,
           t: validToken,
-          // v: 'deployment-2',
+          ht: 1,
+          c: 'USA',
+          l: '/p/:id',
+          l0: '/p/:id',
+          ct: '4g',
+        })
+      })
+
+      it('should use layer0 mappings on server-timing headers (backward compatibility test)', () => {
+        document.cookie = 'xdn_destination=A'
+
+        // Try adding connection before the constructor for full code coverage
+        window.navigator.connection = { effectiveType: '4g' }
+
+        const metrics = new Metrics({
+          token: validToken,
+          cacheManifestTTL: 0,
+        })
+
+        timing = {
+          'edgio-cache': 'L1-HIT',
+          'xdn-deployment-id': 'deployment-2',
+          xrj: '{ "path": "/p/:id" }',
+          country: 'USA',
+        }
+
+        expect(JSON.parse(metrics.createPayload())).toEqual({
+          ...commonParams,
+          t: validToken,
+          v: 'deployment-2',
           ht: 1,
           c: 'USA',
           l: '/p/:id',


### PR DESCRIPTION
This PR is more like a suggestion, until we test this on Sailfish we cannot release this. Also, there are some timing values (like deplomentId) which are not sent by Sailfish and we need to check whether there should be a workaround or we can just ignore it. 

Sailfish implementation of server-timing:
https://gitlab.com/limelight-networks/edgecast/mirrors/http-dev/sailfish/-/commit/b7bcbafe29945dece5530509556bf954a5bae566